### PR TITLE
Remove "difficult SGX support" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,7 @@ If you need a SGX capable server have a look at the [Intel SGX server block](htt
 | Laptop | ASUS | X456UA | [see Issue 18](https://github.com/ayeks/SGX-hardware/issues/18) | 18 April 2017 |  |
 | Workstation | HP  | Z2 Mini G3  | [see Pull request 19](https://github.com/ayeks/SGX-hardware/pull/19) | 21 April 2017 | HP Z2 Mini G3, CPU Xeon E3-1245 v5 |
 | Workstation | HP  | HP Z240 Tower Workstation  | N51 Ver. 01.54 ] | 16 Mar 2017 | HP Z240 Tower Workstation, Intel(R) Xeon(R) CPU E3-1240 v5 @ 3.50GHz|
-
-## Hardware with no/difficult SGX support
-
-In course of the last years it became clear that some devices are SGX capable in theory, but are sometimes missing some essential software components to run SGX enclaves. 
-
-| Device | Vendor | Model |  Source | Date | Problem |
-|--------|--------|-------|---------|------|-----------|
-| Server | Supermicro | system [5019-MR](http://www.supermicro.com/products/system/1U/5019/SYS-5019S-MR.cfm), mainboard [X11SSH-F Bios 1.0b](http://www.supermicro.com/products/motherboard/Xeon/C236_C232/X11SSH-F.cfm) | [Pressrelease](http://www.supermicro.com/newsroom/pressreleases/2015/press150901_Embedded_IoT_Skylake.cfm) [see Issue 6](https://github.com/ayeks/SGX-hardware/issues/6) | 19 May 2016| [no trusted services](https://github.com/ayeks/SGX-hardware/issues/24) |
+| Server | Supermicro | system [5019-MR](http://www.supermicro.com/products/system/1U/5019/SYS-5019S-MR.cfm), mainboard [X11SSH-F BIOS 1.0b or 2.0b](http://www.supermicro.com/products/motherboard/Xeon/C236_C232/X11SSH-F.cfm) | [Pressrelease](http://www.supermicro.com/newsroom/pressreleases/2015/press150901_Embedded_IoT_Skylake.cfm) [see Issue 6](https://github.com/ayeks/SGX-hardware/issues/6) | 19 May 2016| [platform services only on specific ME versions](https://github.com/ayeks/SGX-hardware/issues/24) |
 
 ## Test SGX
 


### PR DESCRIPTION
SGX works fine on SuperMicro servers. Platform services are not needed for most of SGX functionality, previous wording was too strong.

Platform services have serious limitations anyway, see https://www.usenix.org/system/files/conference/usenixsecurity17/sec17-matetic.pdf