### PR TITLE
Update Alibaba Cloud status to public preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Both [AWS](https://github.com/ayeks/SGX-hardware/issues/37) and [Google](https:/
 | packet.net | [Reserved Hardware](https://www.packet.com/cloud/all-features/) | YES, SGX1 | YES | Apr 2018 | [Issue 44](https://github.com/ayeks/SGX-hardware/issues/44) |
 | Alibaba Cloud | [ECS Bare Metal Instance](https://www.alibabacloud.com/product/ebm) | YES, unknown version | YES | Sep 2018 | [Docs](https://www.alibabacloud.com/help/doc-detail/60576.html), [Issue 50](https://github.com/ayeks/SGX-hardware/issues/50) |
 | OVHcloud  | [Infrastructure Dedicated Servers](https://www.ovh.com/ca/en/dedicated-servers/infra/) | YES, unknown version | YES | Sep 2019 | [Docs](https://www.ovh.ie/dedicated_servers/software-guard-extensions/), [Issue 66](https://github.com/ayeks/SGX-hardware/issues/66) |
-| Alibaba Cloud | ECS Security-enhanced family (invitational preview) | YES, SGX2 | YES | May 2021 | [Docs](https://www.alibabacloud.com/help/doc-detail/25378.htm#d11e373) |
+| Alibaba Cloud | ECS Security-enhanced family (public preview) | YES, SGX2 | YES | July 2021 | [Docs](https://www.alibabacloud.com/help/en/doc-detail/207734.htm) |
 
 ## Device with a SGX CPU, but no BIOS support
 


### PR DESCRIPTION
Alibaba Cloud has publicly released the public beta version of the SGX 2.0 ECS instance. According to the documentation, the maximum EPC supported is 512GB. [docs](https://www.alibabacloud.com/help/en/doc-detail/108492.htm#section-kni-2nn-01u)

Here are some tests on the instance.
```bash
[root@hostname~]# ./test-sgx
eax: 606a6 ebx: 50c0800 ecx: fefa320b edx: 1f8bfbff
stepping 6
model 10
family 6
processor type 0
extended model 6
extended family 0
smx: 0

Extended feature bits (EAX=07H, ECX=0H)
eax: 0 ebx: f03f07af ecx: 40405f42 edx: 10
sgx available: 1
sgx launch control: 1

CPUID Leaf 12H, Sub-Leaf 0 of Intel SGX Capabilities (EAX=12H,ECX=0)
eax: 3 ebx: 1 ecx: 0 edx: 381f
sgx 1 supported: 1
sgx 2 supported: 1
MaxEnclaveSize_Not64: 1f
MaxEnclaveSize_64: 38

CPUID Leaf 12H, Sub-Leaf 1 of Intel SGX Capabilities (EAX=12H,ECX=1)
eax: b6 ebx: 0 ecx: e7 edx: 0

CPUID Leaf 12H, Sub-Leaf 2 of Intel SGX Capabilities (EAX=12H,ECX=2)
eax: 40000001 ebx: 6 ecx: d0000002 edx: 5
size of EPC section in Processor Reserved Memory, 23808 M

CPUID Leaf 12H, Sub-Leaf 3 of Intel SGX Capabilities (EAX=12H,ECX=3)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 4 of Intel SGX Capabilities (EAX=12H,ECX=4)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 5 of Intel SGX Capabilities (EAX=12H,ECX=5)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 6 of Intel SGX Capabilities (EAX=12H,ECX=6)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 7 of Intel SGX Capabilities (EAX=12H,ECX=7)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 8 of Intel SGX Capabilities (EAX=12H,ECX=8)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M

CPUID Leaf 12H, Sub-Leaf 9 of Intel SGX Capabilities (EAX=12H,ECX=9)
eax: 0 ebx: 0 ecx: 0 edx: 0
size of EPC section in Processor Reserved Memory, 0 M
```