### PR TITLE
doc(README.md): Fix compile descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,19 +177,19 @@ You can check if SGX is enabled on you system with `test_sgx.c`. Just compile an
 - Linux / gcc 13.1
 
 ```bash
-gcc -Wl,--no-as-needed -Wall -Wextra -Wpedantic -masm=intel -o test-sgx -lcap cpuid.c rdmsr.c test-sgx.c
+gcc -Wl,--no-as-needed -Wall -Wextra -Wpedantic -masm=intel -o test-sgx -lcap cpuid.c rdmsr.c xsave.c vdso.c test-sgx.c
 ```
 
 - Windows 11 / Visual Studio 2022 (x64 Native Tools)
 
 ```bash
-cl test-sgx.c cpuid.c rdmsr.c
+cl test-sgx.c cpuid.c rdmsr.c xsave.c vdso.c
 ```
 
 - MacOS / Clang 15
 
 ```bash
-clang -Wall -Wextra -Wpedantic -masm=intel -std=c2x -Wno-gnu-binary-literal -o test-sgx cpuid.c rdmsr.c test-sgx.c
+clang -Wall -Wextra -Wpedantic -masm=intel -std=c2x -Wno-gnu-binary-literal -o test-sgx cpuid.c rdmsr.c xsave.c vdso.c test-sgx.c
 ```
 
 See [Issue 17](https://github.com/ayeks/SGX-hardware/issues/17) for the execution in Visual Studio.


### PR DESCRIPTION
Hi! It seems that some parameters are missing in the compile command, causing a compilation error.

```bash
$ gcc -Wl,--no-as-needed -Wall -Wextra -Wpedantic -masm=intel -o test-sgx -lcap cpuid.c rdmsr.c test-sgx.c
/usr/bin/ld: /tmp/ccjtNltm.o: in function `main':
test-sgx.c:(.text+0x81): undefined reference to `dump_vDSO'
/usr/bin/ld: test-sgx.c:(.text+0x99): undefined reference to `print_XSAVE_enumeration'
collect2: error: ld returned 1 exit status
```

Adding `xsave.c` and `vdso.c` resolves the issue.